### PR TITLE
Fix: ru translation

### DIFF
--- a/pretty_lootalert_TBC.toc
+++ b/pretty_lootalert_TBC.toc
@@ -1,7 +1,7 @@
 ## Interface: 20502
 ## Title: |cff00ffff*|r |cfffff0f5pretty_lootalert|r
 ## Notes: |cffcaf7faLoot toast addon from pretty stuff|r
-## Notes-ruRU: |cffcaf7faОповещение о луте из прекрасного стаффа|r
+## Notes-ruRU: |cffcaf7faКрасивый аддон оповещения о добыче|r
 ## Version: 2.0
 ## Author: s0high
 

--- a/pretty_lootalert_Vanilla.toc
+++ b/pretty_lootalert_Vanilla.toc
@@ -1,7 +1,7 @@
 ## Interface: 11402
 ## Title: |cff00ffff*|r |cfffff0f5pretty_lootalert|r
 ## Notes: |cffcaf7faLoot toast addon from pretty stuff|r
-## Notes-ruRU: |cffcaf7faОповещение о луте из прекрасного стаффа|r
+## Notes-ruRU: |cffcaf7faКрасивый аддон оповещения о добыче|r
 ## Version: 2.0
 ## Author: s0high
 


### PR DESCRIPTION
I have no idea what author means there: `Loot toast addon from pretty stuff`, so I just translated it how it should be on Russian (the addon means).